### PR TITLE
 Le champ "Déposé par" dans les informations d'un document, depuis un compte bénéf, est vide

### DIFF
--- a/src/Entity/Document.php
+++ b/src/Entity/Document.php
@@ -104,7 +104,7 @@ class Document extends DonneePersonnelle
     private ?int $folderId = null;
 
     #[Groups(['document:read', 'read-personal-data', 'read-personal-data-v2', 'v3:document:read'])]
-    private ?int $deposeParFullName = null;
+    private ?string $deposeParFullName = null;
 
     private ?Collection $sharedDocuments;
 
@@ -383,15 +383,8 @@ class Document extends DonneePersonnelle
         return $this;
     }
 
-    public function getDeposeParFullName(): ?int
+    public function getDeposeParFullName(): ?string
     {
-        return $this->deposeParFullName;
-    }
-
-    public function setDeposeParFullName(?int $deposeParFullName): self
-    {
-        $this->deposeParFullName = $deposeParFullName;
-
-        return $this;
+        return $this->getCreatorUserFullName();
     }
 }


### PR DESCRIPTION
[Ticket](https://trello.com/c/AebLuKnQ/3643-5-le-champ-d%C3%A9pos%C3%A9-par-dans-les-informations-dun-document-depuis-un-compte-b%C3%A9n%C3%A9f-est-vide)
