### PR TITLE
Etape 1/4 : sur chrome toujours impossible de mettre un numéro de téléphone → : que je mette des espaces ou non, j’ai toujours “Le téléphone ne doit pas être vide” → constaté sur Chrome uniquement (sur Firefox, ça fonctionne)

### DIFF
--- a/assets/controllers/intl_tel_input_controller.js
+++ b/assets/controllers/intl_tel_input_controller.js
@@ -18,4 +18,3 @@ export default class extends Controller {
     });
   }
 }
-

--- a/src/ControllerV2/ProController.php
+++ b/src/ControllerV2/ProController.php
@@ -83,7 +83,7 @@ class ProController extends AbstractController
     #[Route(path: '/create', name: 'create_pro', methods: ['GET', 'POST'])]
     public function createPro(Request $request, EntityManagerInterface $em, UserManager $manager): Response
     {
-        $user = (new User())->setSubjectMembre(new Membre());
+        $user = User::createPro();
         $form = $this->createForm(CreateUserType::class, $user, [
             'action' => $this->generateUrl('create_pro'),
         ])->handleRequest($request);

--- a/src/Entity/Subject.php
+++ b/src/Entity/Subject.php
@@ -28,7 +28,7 @@ abstract class Subject implements \JsonSerializable
 
     public function getFullName(): string
     {
-        return $this->user->getFullName();
+        return $this->user?->getFullName() ?? '';
     }
 
     public function getUserId(): ?int
@@ -50,7 +50,7 @@ abstract class Subject implements \JsonSerializable
 
     public function getDefaultUsername(): string
     {
-        return sprintf('%s.%s', $this->user->getSluggedLastname(), $this->user->getSluggedFirstName());
+        return sprintf('%s.%s', $this->user?->getSluggedLastname() ?? '', $this->user?->getSluggedFirstName() ?? '');
     }
 
     public function getUsername(): ?string

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -196,6 +196,14 @@ class User extends BaseUser implements \JsonSerializable
         $this->creators = new ArrayCollection();
     }
 
+    public static function createPro(): self
+    {
+        $user = new self();
+        (new Membre())->setUser($user);
+
+        return $user;
+    }
+
     public function getUserIdentifier(): string
     {
         return $this->username;

--- a/src/FormV2/UserCreation/CreateUserType.php
+++ b/src/FormV2/UserCreation/CreateUserType.php
@@ -31,7 +31,10 @@ class CreateUserType extends AbstractType
                     'class' => 'col-6 mt-3',
                     'data-controller' => 'intl-tel-input',
                 ],
-                'attr' => ['data-intl-tel-input-target' => 'input'],
+                'attr' => [
+                    'data-intl-tel-input-target' => 'input',
+                    'autocomplete' => 'tel',
+                ],
             ])
             ->addEventSubscriber(new AddFormattedPhoneSubscriber())
             ->add('email', EmailType::class, [

--- a/src/FormV2/UserInformationType.php
+++ b/src/FormV2/UserInformationType.php
@@ -25,17 +25,21 @@ class UserInformationType extends AbstractType
             ->add('telephone', null, [
                 'required' => false,
                 'label' => 'phone',
-                'row_attr' => ['class' => 'col-6 mt-3'],
+                'row_attr' => [
+                    'class' => 'col-6 mt-3',
+                    'data-controller' => 'intl-tel-input',
+                ],
                 'attr' => [
-                    'class' => 'intl-tel-input',
+                    'data-intl-tel-input-target' => 'input',
+                    'autocomplete' => 'tel',
                 ],
             ])
+            ->addEventSubscriber(new AddFormattedPhoneSubscriber())
             ->add('email', EmailType::class, [
                 'required' => false,
                 'row_attr' => ['class' => 'col-6 mt-3'],
                 'label' => 'email',
-            ])
-            ->addEventSubscriber(new AddFormattedPhoneSubscriber());
+            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/templates/v2/common/_card_with_form.html.twig
+++ b/templates/v2/common/_card_with_form.html.twig
@@ -9,9 +9,7 @@
                 {{ form_errors(field) }}
             {% endfor %}
         </div>
-        <div class="text-end">
-            {{ include('v2/common/_button.html.twig', {message: buttonText, color: 'outline-primary'}) }}
-        </div>
+        {{ include('v2/common/_form_actions.html.twig') }}
         {{ form_end(form) }}
     </div>
 {% endblock %}

--- a/templates/v2/common/_form_actions.html.twig
+++ b/templates/v2/common/_form_actions.html.twig
@@ -1,0 +1,10 @@
+<div class="d-flex justify-content-between mt-4">
+    <div>
+        {% if backPath is defined %}
+            {{ include('v2/common/_button.html.twig', {message: 'back'|trans, color: 'primary'}) }}
+        {% endif %}
+    </div>
+    <div>
+        {{ include('v2/common/_button.html.twig', {message: buttonText, color: 'outline-primary'}) }}
+    </div>
+</div>

--- a/templates/v2/user_creation/beneficiary/_step_form.html.twig
+++ b/templates/v2/user_creation/beneficiary/_step_form.html.twig
@@ -11,26 +11,19 @@
         <div class="h-100 d-flex flex-column justify-content-between">
             <div>
                 {% if beneficiaryCreationProcess.isPasswordStep %}
-                    {{ include('v2/user_creation/components/_generate_password_input.html.twig', {field: form.password}) }}
+                    {{ include('v2/user_creation/components/_password_card.html.twig', {form, title: 'create_new_beneficiary'|trans,}) }}
                 {% else %}
-                    {{ form_widget(form) }}
-                {% endif %}
-            </div>
-            <div class="text-center mt-4 row">
-                <div class="col-6 d-grid gap-2">
-                    {{ include('v2/common/_button_with_loader.html.twig', {
-                        text: 'back'|trans,
-                        href: path('create_beneficiary', {
+                    {{ include('v2/common/_card_with_form.html.twig', {
+                        form,
+                        title: 'create_new_beneficiary'|trans,
+                        backPath: path('create_beneficiary', {
                             step: beneficiaryCreationProcess.previousStep,
                             id: beneficiaryCreationProcess.id,
                         })
                     }) }}
-                </div>
-                <div class="col-6 d-grid gap-2">
-                    {{ include('v2/common/_button_with_loader.html.twig', {text: 'confirm'|trans, color: 'blue'}) }}
-                </div>
-                {{ form_end(form) }}
+                {% endif %}
             </div>
         </div>
+        {{ form_end(form) }}
     </div>
 {% endblock %}

--- a/templates/v2/user_creation/components/_password_card.html.twig
+++ b/templates/v2/user_creation/components/_password_card.html.twig
@@ -1,0 +1,8 @@
+{% extends 'v2/common/_card.html.twig' %}
+
+{% block customContent %}
+    <div class="text-start">
+        {{ include('v2/user_creation/components/_generate_password_input.html.twig', {field: form.password}) }}
+        {{ include('v2/common/_form_actions.html.twig') }}
+    </div>
+{% endblock %}

--- a/tests/v2/Controller/BeneficiaryCreationController/BeneficiaryCreationStep1Test.php
+++ b/tests/v2/Controller/BeneficiaryCreationController/BeneficiaryCreationStep1Test.php
@@ -54,7 +54,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
     {
         yield 'Should redirect to step 2 when form is correct' => [
             self::URL,
-            'confirm',
+            'submit',
             self::FORM_VALUES,
             MemberFixture::MEMBER_MAIL,
             '/beneficiary/create/2/%s',
@@ -77,7 +77,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
         yield 'Should return an error when nom is empty' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [
@@ -95,7 +95,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
         yield 'Should return an error when prenom is empty' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [
@@ -113,7 +113,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
         yield 'Should return an error if email already used' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [
@@ -131,7 +131,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
         yield 'Should return an error if email is not correct' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [

--- a/tests/v2/Controller/BeneficiaryCreationController/BeneficiaryCreationStep2Test.php
+++ b/tests/v2/Controller/BeneficiaryCreationController/BeneficiaryCreationStep2Test.php
@@ -55,7 +55,7 @@ class BeneficiaryCreationStep2Test extends AbstractControllerTest implements Tes
     {
         yield 'Should redirect to step 2 when form is correct' => [
             self::URL,
-            'confirm',
+            'submit',
             self::FORM_VALUES,
             MemberFixture::MEMBER_MAIL,
             '/beneficiary/create/3/%s',
@@ -83,7 +83,7 @@ class BeneficiaryCreationStep2Test extends AbstractControllerTest implements Tes
         yield 'Should return an error when password is empty' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [
@@ -101,7 +101,7 @@ class BeneficiaryCreationStep2Test extends AbstractControllerTest implements Tes
         yield 'Should return an error when password length < 5' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [

--- a/tests/v2/Controller/BeneficiaryCreationController/BeneficiaryCreationStep3Test.php
+++ b/tests/v2/Controller/BeneficiaryCreationController/BeneficiaryCreationStep3Test.php
@@ -61,7 +61,7 @@ class BeneficiaryCreationStep3Test extends AbstractControllerTest implements Tes
     {
         yield 'Should redirect to step 4 when form is correct' => [
             self::URL,
-            'confirm',
+            'submit',
             self::FORM_VALUES,
             MemberFixture::MEMBER_MAIL,
             '/beneficiary/create/4/%s',
@@ -89,7 +89,7 @@ class BeneficiaryCreationStep3Test extends AbstractControllerTest implements Tes
         yield 'Should return an error when answer is empty' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [
@@ -107,7 +107,7 @@ class BeneficiaryCreationStep3Test extends AbstractControllerTest implements Tes
         yield 'Should return an error when answer length < 3 ' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [

--- a/tests/v2/Controller/BeneficiaryCreationController/BeneficiaryCreationStep4Test.php
+++ b/tests/v2/Controller/BeneficiaryCreationController/BeneficiaryCreationStep4Test.php
@@ -73,7 +73,7 @@ class BeneficiaryCreationStep4Test extends AbstractControllerTest implements Tes
     {
         yield 'Should redirect to step 5 when form is correct' => [
             self::URL,
-            'confirm',
+            'submit',
             self::FORM_VALUES,
             MemberFixture::MEMBER_MAIL_WITH_RELAYS,
             '/beneficiary/create/5/%s',

--- a/tests/v2/Controller/BeneficiaryCreationController/Remotely/BeneficiaryCreationStep1Test.php
+++ b/tests/v2/Controller/BeneficiaryCreationController/Remotely/BeneficiaryCreationStep1Test.php
@@ -54,7 +54,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
     {
         yield 'Should redirect to step 2 when form is correct' => [
             self::URL,
-            'confirm',
+            'submit',
             self::FORM_VALUES,
             MemberFixture::MEMBER_MAIL,
             '/beneficiary/create/2/%s',
@@ -77,7 +77,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
         yield 'Should return an error when nom is empty' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [
@@ -95,7 +95,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
         yield 'Should return an error when prenom is empty' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [
@@ -113,7 +113,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
         yield 'Should return an error if email already used' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [
@@ -131,7 +131,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
         yield 'Should return an error if phone empty' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [
@@ -149,7 +149,7 @@ class BeneficiaryCreationStep1Test extends AbstractControllerTest implements Tes
         yield 'Should return an error if email is not correct' => [
             self::URL,
             'create_beneficiary',
-            'confirm',
+            'submit',
             $values,
             [
                 [

--- a/tests/v2/Controller/BeneficiaryCreationController/Remotely/BeneficiaryCreationStep2Test.php
+++ b/tests/v2/Controller/BeneficiaryCreationController/Remotely/BeneficiaryCreationStep2Test.php
@@ -75,7 +75,7 @@ class BeneficiaryCreationStep2Test extends AbstractControllerTest implements Tes
     {
         yield 'Should redirect to step 3 when form is correct' => [
             self::URL,
-            'confirm',
+            'submit',
             self::FORM_VALUES,
             MemberFixture::MEMBER_MAIL_WITH_RELAYS,
             '/beneficiary/create/3/%s',


### PR DESCRIPTION
[Ticket](https://trello.com/c/cHcgj04R/3840-etape-1-4-sur-chrome-toujours-impossible-de-mettre-un-num%C3%A9ro-de-t%C3%A9l%C3%A9phone-%E2%86%92-que-je-mette-des-espaces-ou-non-jai-toujours-le-t%C3%A9l%C3%A9)
