### PR TITLE
[Main] Quand on affilie un membre à un centre il est par défaut en “Gestion des bénéficiaires” en droit

### DIFF
--- a/assets/controllers/tooltip_controller.js
+++ b/assets/controllers/tooltip_controller.js
@@ -1,0 +1,8 @@
+import {Controller} from '@hotwired/stimulus';
+import $ from 'jquery';
+
+export default class extends Controller {
+  connect() {
+    $('[data-toggle="tooltip"]').tooltip()
+  }
+}

--- a/assets/css/appV2/theme.scss
+++ b/assets/css/appV2/theme.scss
@@ -38,6 +38,11 @@ label:focus,
   box-shadow: none !important;
 }
 
+.blue-tooltip {
+  --bs-tooltip-bg: var(--bs-blue);
+  --bs-tooltip-opacity: 1;
+}
+
 $hr-opacity: 100%;
 
 .hr-2 {

--- a/src/Entity/MembreCentre.php
+++ b/src/Entity/MembreCentre.php
@@ -11,6 +11,10 @@ class MembreCentre extends UserCentre
 {
     public const TYPEDROIT_GESTION_BENEFICIAIRES = 'gestionbeneficiaires';
     public const TYPEDROIT_GESTION_MEMBRES = 'gestionmembres';
+    public const PERMISSIONS = [
+        self::TYPEDROIT_GESTION_BENEFICIAIRES,
+        self::TYPEDROIT_GESTION_MEMBRES,
+    ];
 
     #[Groups(['v3:center:read', 'v3:center:write'])]
     private $centre;
@@ -128,9 +132,16 @@ class MembreCentre extends UserCentre
 
     public function togglePermission(string $permission): void
     {
-        if (!array_key_exists($permission, $this->getDroits())) {
+        if (!in_array($permission, self::PERMISSIONS)) {
             return;
         }
+
+        if (!array_key_exists($permission, $this->droits)) {
+            $this->droits[$permission] = true;
+
+            return;
+        }
+
         $this->droits[$permission] = !$this->droits[$permission];
     }
 

--- a/src/Entity/MembreCentre.php
+++ b/src/Entity/MembreCentre.php
@@ -31,6 +31,15 @@ class MembreCentre extends UserCentre
         ];
     }
 
+    public function __construct()
+    {
+        parent::__construct();
+        $this->droits = [
+            self::TYPEDROIT_GESTION_BENEFICIAIRES => true,
+            self::TYPEDROIT_GESTION_MEMBRES => false,
+        ];
+    }
+
     /**
      * Get centre.
      *

--- a/src/ManagerV2/RelayManager.php
+++ b/src/ManagerV2/RelayManager.php
@@ -69,12 +69,6 @@ class RelayManager
         $this->em->flush();
     }
 
-    public function addUserToRelay(User $user, Centre $relay): void
-    {
-        $this->em->persist(User::createUserRelay($user, $relay));
-        $this->em->flush();
-    }
-
     /** @return UserCentre[] */
     public function getPendingRelays(?User $user): array
     {

--- a/templates/v2/base.html.twig
+++ b/templates/v2/base.html.twig
@@ -17,7 +17,7 @@
 
     {{ include('favicons.html.twig') }}
 </head>
-<body class="d-flex flex-column">
+<body class="d-flex flex-column" {{ stimulus_controller('tooltip') }}>
 {{ include('v2/header/header.html.twig') }}
 
 <main role="main" class="position-relative {% block bodyColor %}{{ getUserBackgroundColor() }}{% endblock %} pb-5">

--- a/templates/v2/common/_card.html.twig
+++ b/templates/v2/common/_card.html.twig
@@ -6,6 +6,7 @@
         {% if tooltipMessage is defined and tooltipMessage %}
             data-toggle="tooltip"
             data-placement="top"
+            data-bs-custom-class="{{ getUserThemeColor() }}-tooltip"
             title="{{ tooltipMessage }}"
         {% endif %}
 >

--- a/templates/v2/pro/list/_update_permission_button.html.twig
+++ b/templates/v2/pro/list/_update_permission_button.html.twig
@@ -32,6 +32,7 @@
                     <i class="fas fa-{{ button.icon }} fa-2x text-{{ currentUserRelay and currentUserRelay.hasDroit(button.permission) ? 'primary' : 'grey ' }}"
                        data-toggle="tooltip"
                        data-placement="top"
+                       data-bs-custom-class="blue-tooltip"
                        title="{{ currentUserRelay ? button.tooltip : 'you_must_select_center_for_right_update'|trans }}"
                     >
                     </i>

--- a/tests/v2/Controller/UserController/ToggleUserInvitationTest.php
+++ b/tests/v2/Controller/UserController/ToggleUserInvitationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Tests\v2\Controller\UserController;
+
+use App\DataFixtures\v2\BeneficiaryFixture;
+use App\DataFixtures\v2\MemberFixture;
+use App\Entity\MembreCentre;
+use App\Tests\Factory\MembreFactory;
+use App\Tests\Factory\RelayFactory;
+use App\Tests\Factory\UserFactory;
+use App\Tests\v2\Controller\AbstractControllerTest;
+
+class ToggleUserInvitationTest extends AbstractControllerTest
+{
+    private const URL = '/user/%s/toggle-invite/%s';
+
+    /** @dataProvider provideTestRoute */
+    public function testRoute(
+        string $url,
+        int $expectedStatusCode,
+        ?string $userMail = null,
+        ?string $expectedRedirect = null,
+        string $method = 'GET',
+        bool $isXmlHttpRequest = false,
+        array $body = [],
+    ): void {
+        // Test toggle pro invite
+        $user = UserFactory::findByEmail(MemberFixture::MEMBER_MAIL)->object();
+        $relay = MembreFactory::findByEmail(MemberFixture::MEMBER_MAIL_WITH_RELAYS)->object()->getCentres()[0];
+        $url = sprintf(self::URL, $user->getId(), $relay->getId());
+
+        $this->assertRoute($url, $expectedStatusCode, $userMail, $expectedRedirect, $method);
+
+        // Test toggle beneficiary invite
+        $user = UserFactory::findByEmail(BeneficiaryFixture::BENEFICIARY_MAIL);
+        $url = sprintf(self::URL, $user->getId(), $relay->getId());
+
+        $this->assertRoute($url, $expectedStatusCode, $userMail, $expectedRedirect, $method);
+    }
+
+    public function provideTestRoute(): ?\Generator
+    {
+        yield 'Should redirect to login when not authenticated on settings page' => [self::URL, 302, null, '/login'];
+        yield 'Should return 403 status code when authenticated as beneficiary' => [self::URL, 403, BeneficiaryFixture::BENEFICIARY_MAIL];
+        yield 'Should return 200 status code when authenticated as member' => [self::URL, 200, MemberFixture::MEMBER_MAIL_WITH_RELAYS];
+    }
+
+    public function testProPermissionOnInvitation(): void
+    {
+        $loggedUser = UserFactory::findByEmail(MemberFixture::MEMBER_MAIL_WITH_RELAYS)->object();
+        $relay = $loggedUser->getCentres()[0];
+        $testedUser = UserFactory::findByEmail(MemberFixture::MEMBER_MAIL_NO_RELAY_NO_PERMISSION)->object();
+
+        self::assertFalse($testedUser->isLinkedToRelay($relay));
+
+        $url = sprintf(self::URL, $testedUser->getId(), $relay->getId());
+        $this->assertRoute($url, 200, MemberFixture::MEMBER_MAIL_WITH_RELAYS);
+
+        $testedUser = UserFactory::find($testedUser)->object();
+        $relay = RelayFactory::find($relay)->object();
+        $userRelay = $testedUser->getUserRelay($relay);
+
+        self::assertSame(
+            [
+                MembreCentre::TYPEDROIT_GESTION_BENEFICIAIRES => true,
+                MembreCentre::TYPEDROIT_GESTION_MEMBRES => false,
+            ],
+            $userRelay->getDroits()
+        );
+    }
+}

--- a/tests/v2/Entity/UserTest.php
+++ b/tests/v2/Entity/UserTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Tests\v2\Entity;
+
+use App\Entity\Centre;
+use App\Entity\MembreCentre;
+use App\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class UserTest extends KernelTestCase
+{
+    public function testCreateProUserRelay(): void
+    {
+        $userRelay = User::createUserRelay(new User(), new Centre());
+
+        self::assertEquals([
+            MembreCentre::TYPEDROIT_GESTION_BENEFICIAIRES => true,
+            MembreCentre::TYPEDROIT_GESTION_MEMBRES => false,
+        ], $userRelay->getDroits());
+    }
+}


### PR DESCRIPTION
[Ticket](https://trello.com/c/HhUAgxBs/3828-2-quand-on-affilie-un-membre-%C3%A0-un-centre-il-est-par-d%C3%A9faut-en-gestion-des-b%C3%A9n%C3%A9ficiaires-en-droit)
++ Traitements des retours: [Ticket](https://trello.com/c/04EDvA8U/3784-8-pro-lister-professionnels-sur-la-card-dun-professionnels-jai-un-composant-pour-modifier-ses-droits)
