### PR TITLE
(3) [Affilier benef existant] Si le bénéf a indiqué un numéro de téléphone, il peut valider l'affiliation par SMS (tests)

### DIFF
--- a/src/ControllerV2/BeneficiaryAffiliationController.php
+++ b/src/ControllerV2/BeneficiaryAffiliationController.php
@@ -96,7 +96,7 @@ class BeneficiaryAffiliationController extends AbstractController
         requirements: ['id' => '\d+'],
         methods: ['GET'],
     )]
-    public function sensSmsAffiliationCode(
+    public function sendSmsAffiliationCode(
         Beneficiaire $beneficiary,
         SMSManager $manager,
         TranslatorInterface $translator,

--- a/tests/v2/Controller/BeneficiaryAffiliationController/SendSmsAffiliationCodeTest.php
+++ b/tests/v2/Controller/BeneficiaryAffiliationController/SendSmsAffiliationCodeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Tests\v2\Controller\BeneficiaryAffiliationController;
+
+use App\DataFixtures\v2\BeneficiaryFixture;
+use App\DataFixtures\v2\MemberFixture;
+use App\Tests\Factory\BeneficiaireFactory;
+use App\Tests\v2\Controller\AbstractControllerTest;
+use App\Tests\v2\Controller\TestRouteInterface;
+
+class SendSmsAffiliationCodeTest extends AbstractControllerTest implements TestRouteInterface
+{
+    private const URL = '/beneficiary/%s/affiliate/send-invitation-sms-code';
+    private const RELAYS_URL = '/beneficiary/%s/affiliate/relays';
+
+    /** @dataProvider provideTestRoute */
+    public function testRoute(
+        string $url,
+        int $expectedStatusCode,
+        string $userMail = null,
+        string $expectedRedirect = null,
+        string $method = 'GET',
+        bool $isXmlHttpRequest = false,
+        array $body = [],
+    ): void {
+        $beneficiary = BeneficiaireFactory::createOne()->object();
+        $url = sprintf($url, $beneficiary->getId());
+        $expectedRedirect = sprintf($expectedRedirect, $beneficiary->getId());
+        $this->assertRoute($url, $expectedStatusCode, $userMail, $expectedRedirect, $method);
+    }
+
+    public function provideTestRoute(): ?\Generator
+    {
+        yield 'Should redirect to login when not authenticated' => [self::URL, 302, null, '/login'];
+        yield 'Should redirect to relays choice when authenticated as professional' => [self::URL, 302, MemberFixture::MEMBER_MAIL, self::RELAYS_URL];
+        yield 'Should return 403 status code when authenticated as beneficiary' => [self::URL, 403, BeneficiaryFixture::BENEFICIARY_MAIL];
+    }
+}

--- a/tests/v2/Validator/SecretAnswerConstraintTest.php
+++ b/tests/v2/Validator/SecretAnswerConstraintTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Tests\v2\Validator;
+
+use App\Entity\Beneficiaire;
+use App\Validator\Constraints\SecretAnswer;
+use App\Validator\Constraints\SecretAnswerValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class SecretAnswerConstraintTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): SecretAnswerValidator
+    {
+        return new SecretAnswerValidator();
+    }
+
+    public function testRightAnswerIsValid()
+    {
+        $this->validator->validate('answer', new SecretAnswer($this->getDummyBeneficiary()));
+
+        $this->assertNoViolation();
+    }
+
+    public function testWrongAnswerIsNotValid()
+    {
+        $constraint = new SecretAnswer($this->getDummyBeneficiary());
+
+        $this->validator->validate('wrong', $constraint);
+
+        $this->buildViolation($constraint->message)->assertRaised();
+    }
+
+    private function getDummyBeneficiary(): Beneficiaire
+    {
+        return (new Beneficiaire())->setReponseSecrete('answer');
+    }
+}


### PR DESCRIPTION
[Ticket](https://trello.com/c/03Y3vfIO/3864-3-affilier-benef-existant-si-le-b%C3%A9n%C3%A9f-a-indiqu%C3%A9-un-num%C3%A9ro-de-t%C3%A9l%C3%A9phone-il-peut-valider-laffiliation-par-sms-tests)
