### PR TITLE
(3) V2 - Si je retire un professionnel d'un relais alors qu'il est affilié à un unique relais, son compte membre est désactivé

### DIFF
--- a/src/Entity/Traits/DeactivatableTrait.php
+++ b/src/Entity/Traits/DeactivatableTrait.php
@@ -51,6 +51,7 @@ trait DeactivatableTrait
     public function disable(User $user = null): self
     {
         $this->setDisabledAt(new \DateTime())->setDisabledBy($user);
+        $this->enabled = false;
 
         return $this;
     }

--- a/src/ManagerV2/RelayManager.php
+++ b/src/ManagerV2/RelayManager.php
@@ -36,6 +36,9 @@ class RelayManager
     {
         if ($userRelay = $user->getUserRelay($relay)) {
             $this->em->remove($userRelay);
+            if ($user->isMembre() && 1 === $user->getUserRelays()->count()) {
+                $user->disable();
+            }
         }
 
         $this->em->flush();

--- a/tests/v2/Manager/RelayManager/RemoveUserFromRelayTest.php
+++ b/tests/v2/Manager/RelayManager/RemoveUserFromRelayTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Tests\v2\Manager\RelayManager;
+
+use App\DataFixtures\v2\MemberFixture;
+use App\Entity\User;
+use App\ManagerV2\RelayManager;
+use App\Repository\UserRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class RemoveUserFromRelayTest extends KernelTestCase
+{
+    private RelayManager $relayManager;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->relayManager = self::getContainer()->get(RelayManager::class);
+    }
+
+    public function testRemoveUserFromRelay(): void
+    {
+        // Given a user and a relay
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        /** @var User $user */
+        $user = $userRepository->findOneBy(['email' => MemberFixture::MEMBER_MAIL]);
+        $relayCount = $user->getRelays()->count();
+        $this->assertNotNull($relayCount);
+        $relay = $user->getRelays()->first();
+        $this->assertNotNull($relay);
+
+        // When removing user from relay
+        $this->relayManager->removeUserFromRelay($user, $relay);
+
+        // User should not be affiliated to relay
+        $this->assertEquals($relayCount - 1, $user->getRelays()->count());
+        $this->assertNotContains($relay, $user->getRelays());
+        $this->assertTrue($user->isEnabled());
+    }
+
+    public function testRemoveUserFromLastRelay(): void
+    {
+        // Given a pro user and a relay
+        /** @var UserRepository $userRepository */
+        $userRepository = self::getContainer()->get(UserRepository::class);
+        /** @var User $user */
+        $user = $userRepository->findOneBy(['email' => MemberFixture::MEMBER_MAIL_WITH_UNIQUE_RELAY_SHARED_WITH_BENEFICIARIES]);
+        $this->assertTrue($user->isEnabled());
+        $relayCount = $user->getRelays()->count();
+        $this->assertEquals(1, $relayCount);
+        $relay = $user->getRelays()->first();
+        $this->assertNotNull($relay);
+        // When removing user from his last relay
+        $this->relayManager->removeUserFromRelay($user, $relay);
+
+        // User should not be affiliated to relay and be disaffiliated
+        $this->assertEquals($relayCount - 1, $user->getRelays()->count());
+        $this->assertNotContains($relay, $user->getRelays());
+        $this->assertFalse($user->isEnabled());
+    }
+}


### PR DESCRIPTION
[Ticket](https://trello.com/c/VOdJ6884/4029-3-v2-si-je-retire-un-professionnel-dun-relais-alors-quil-est-affili%C3%A9-%C3%A0-un-unique-relais-son-compte-membre-est-d%C3%A9sactiv%C3%A9)
