### PR TITLE
Modifier "Gestion professionnels" en "Gestion d'équipe" + Sur la création d'un bénéficiaire pas de tooltip sur les checkboxes d'affiliation

### DIFF
--- a/templates/v2/user_creation/components/_permissions_checkboxes.html.twig
+++ b/templates/v2/user_creation/components/_permissions_checkboxes.html.twig
@@ -16,7 +16,7 @@
         isUpdatable: is_granted('MANAGE_BENEFICIARIES', relay),
     },
     {
-        name: 'pro_management'|trans,
+        name: 'team_management'|trans,
         value: constant('App\\Entity\\MembreCentre::MANAGE_PROS_PERMISSION'),
         icon: 'user-cog',
         isOwned: userRelay and userRelay.canManageProfessionals,

--- a/templates/v2/user_creation/components/_relays_checkbox.html.twig
+++ b/templates/v2/user_creation/components/_relays_checkbox.html.twig
@@ -1,10 +1,14 @@
-{% set hasValidLinkToRelay = user.hasValidLinkToRelay(relay) %}
 {% set isPro = user.hasRole('ROLE_MEMBRE') %}
+{% set isBeneficiaryInCreation = not isPro and user.subjectBeneficiaire.isCreating %}
+{% set hasValidLinkToRelay = user.hasValidLinkToRelay(relay) %}
 {% set isLinkedToRelay = user.isLinkedToRelay(relay) %}
-{% set isUpdatable = not isPro and user.subjectBeneficiaire.isCreating or not hasValidLinkToRelay %}
+{% set isUpdatable = isBeneficiaryInCreation or not hasValidLinkToRelay %}
 {% set checkboxColor = isLinkedToRelay ? activeClasses : inactiveClasses %}
-{% if hasValidLinkToRelay %}
-    {% set tooltipMessage = isPro ? 'pro_already_affiliated_to_relay'|trans : 'beneficiary_already_affiliated_to_relay'|trans %}
+
+{% if hasValidLinkToRelay and isPro %}
+    {% set tooltipMessage = 'pro_already_affiliated_to_relay'|trans %}
+{% elseif hasValidLinkToRelay and not isPro %}
+    {% set tooltipMessage = isBeneficiaryInCreation ? '' : 'beneficiary_already_affiliated_to_relay'|trans %}
 {% endif %}
 
 <div class="py-1 d-flex w-100">


### PR DESCRIPTION
[Ticket](https://trello.com/c/FAMAPzEj/4315-1-sur-la-cr%C3%A9ation-dun-b%C3%A9n%C3%A9ficiaire-%C3%A7a-a-pas-de-sens-de-mettre-le-tooltip-le-b%C3%A9n%C3%A9ficiaire-est-d%C3%A9j%C3%A0-affili%C3%A9-%C3%A0-ce-centre-%C3%A9tant-donn)
[Ticket](https://trello.com/c/zQkYn7Oz/4302-05-modifier-gestion-professionnels-en-gestion-d%C3%A9quipe)
