### PR TITLE
ETQP à la création d'un bénéficiaire, les chips de validation du password doivent fonctionner

### DIFF
--- a/src/Form/Type/UserType.php
+++ b/src/Form/Type/UserType.php
@@ -4,6 +4,7 @@ namespace App\Form\Type;
 
 use App\Entity\User;
 use App\EventSubscriber\AddFormattedPhoneSubscriber;
+use App\FormV2\Field\PasswordField;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -20,8 +21,7 @@ class UserType extends AbstractType
             ->add('plainPassword', PasswordType::class, [
                 'label' => 'password',
                 'attr' => [
-                    'data-password-strength-target' => 'input',
-                    'data-action' => 'password-strength#check',
+                    ...PasswordField::PASSWORD_STRENGTH_CONTROLLER_DATA_ATTRIBUTES,
                     'autocomplete' => 'new-password',
                 ],
             ])

--- a/src/FormV2/ChangePasswordFormType.php
+++ b/src/FormV2/ChangePasswordFormType.php
@@ -2,6 +2,7 @@
 
 namespace App\FormV2;
 
+use App\FormV2\Field\PasswordField;
 use App\Validator\Constraints\PasswordCriteria;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -28,9 +29,8 @@ class ChangePasswordFormType extends AbstractType
                     'constraints' => [new PasswordCriteria()],
                     'label' => 'your_new_password',
                     'attr' => [
+                        ...PasswordField::PASSWORD_STRENGTH_CONTROLLER_DATA_ATTRIBUTES,
                         'autocomplete' => 'new-password',
-                        'data-password-strength-target' => 'input',
-                        'data-action' => 'password-strength#check',
                     ],
                 ],
                 'second_options' => [

--- a/src/FormV2/Field/PasswordField.php
+++ b/src/FormV2/Field/PasswordField.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\FormV2\Field;
+
+class PasswordField
+{
+    public const PASSWORD_STRENGTH_CONTROLLER_DATA_ATTRIBUTES = [
+        'data-password-strength-target' => 'input',
+        'data-action' => 'password-strength#check',
+    ];
+}

--- a/src/FormV2/UserCreation/CreateBeneficiaryType.php
+++ b/src/FormV2/UserCreation/CreateBeneficiaryType.php
@@ -5,6 +5,7 @@ namespace App\FormV2\UserCreation;
 use App\Entity\Attributes\BeneficiaryCreationProcess;
 use App\Entity\Beneficiaire;
 use App\Entity\User;
+use App\FormV2\Field\PasswordField;
 use App\FormV2\UserType;
 use App\ServiceV2\Traits\UserAwareTrait;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -64,6 +65,7 @@ class CreateBeneficiaryType extends AbstractType
             ->add('password', TextType::class, [
                 'property_path' => 'user.plainPassword',
                 'label' => 'password',
+                'attr' => PasswordField::PASSWORD_STRENGTH_CONTROLLER_DATA_ATTRIBUTES,
             ])
             ->add('mfaEnabled', CheckboxType::class, [
                 'property_path' => 'user.mfaEnabled',

--- a/src/FormV2/UserCreation/CreateUserType.php
+++ b/src/FormV2/UserCreation/CreateUserType.php
@@ -4,6 +4,7 @@ namespace App\FormV2\UserCreation;
 
 use App\Entity\User;
 use App\EventSubscriber\AddFormattedPhoneSubscriber;
+use App\FormV2\Field\PasswordField;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -50,9 +51,8 @@ class CreateUserType extends AbstractType
                 'first_options' => [
                     'label' => 'password',
                     'attr' => [
+                        ...PasswordField::PASSWORD_STRENGTH_CONTROLLER_DATA_ATTRIBUTES,
                         'autocomplete' => 'new-password',
-                        'data-password-strength-target' => 'input',
-                        'data-action' => 'password-strength#check',
                     ],
                     'row_attr' => ['class' => 'col-6'],
                 ],

--- a/templates/v2/user_creation/components/_password_card.html.twig
+++ b/templates/v2/user_creation/components/_password_card.html.twig
@@ -3,7 +3,7 @@
 {% block customContent %}
     <div class="text-start">
         {% for field in form %}
-            {#          The 'plainPassword' field name is only used when creating a professionnal #}
+            {# The 'plainPassword' field name is only used when creating a professionnal #}
             {% if field.vars.name == 'password' %}
                 {{ include('v2/user/strong_password/_strong_password_row.html.twig', {
                     'field': form.password,


### PR DESCRIPTION
[Ticket](https://trello.com/c/xTV5G92o/4731-2-etqp-%C3%A0-la-cr%C3%A9ation-dun-b%C3%A9n%C3%A9ficiaire-les-chips-de-validation-du-password-doivent-fonctionner)
