### PR TITLE
Admin : pourquoi sur les membres les "créé par" sont vides ?

### DIFF
--- a/src/EventSubscriber/UserCreationSubscriber.php
+++ b/src/EventSubscriber/UserCreationSubscriber.php
@@ -58,6 +58,7 @@ class UserCreationSubscriber
             $this->setupClientLink($object);
         } elseif ($object instanceof User) {
             $user = $object;
+            $this->addCreators($user);
             $user->formatPhone();
         } else {
             return;
@@ -130,9 +131,11 @@ class UserCreationSubscriber
 
     private function addCreators(?User $user): void
     {
-        $this->addCreatorUser($user);
-        $this->addCreatorRelay($user);
-        $this->addCreatorClient($user);
+        if ($user->getSubjectBeneficiaire() || $user->getSubjectMembre()) {
+            $this->addCreatorUser($user);
+            $this->addCreatorRelay($user);
+            $this->addCreatorClient($user);
+        }
     }
 
     private function hasUsernameInformationChanged(PreUpdateEventArgs $event): bool

--- a/tests/v2/EventSubscriber/UserCreationSubscriberTest.php
+++ b/tests/v2/EventSubscriber/UserCreationSubscriberTest.php
@@ -4,8 +4,10 @@ namespace App\Tests\v2\EventSubscriber;
 
 use App\Entity\Beneficiaire;
 use App\Tests\Factory\BeneficiaireFactory;
+use App\Tests\Factory\MembreFactory;
 use App\Tests\Factory\RelayFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\ModelFactory;
 
 class UserCreationSubscriberTest extends KernelTestCase
 {
@@ -27,16 +29,23 @@ class UserCreationSubscriberTest extends KernelTestCase
         $this->assertEquals($expectedUsername, $user->getUsername());
     }
 
-    public function testAddCreatorRelay(): void
+    /**
+     * @dataProvider provideTestAddCreatorRelay
+     */
+    public function testAddCreatorRelay(ModelFactory $modelFactory): void
     {
         $relay = RelayFactory::createOne()->object();
-        /** @var Beneficiaire $beneficiary */
-        $beneficiary = BeneficiaireFactory::new()
+        $subject = $modelFactory
             ->linkToRelays([$relay])
             ->create()
             ->object();
-        $user = $beneficiary->getUser();
 
-        $this->assertEquals($relay, $user->getCreatorCentreRelay());
+        $this->assertEquals($relay, $subject->getUser()->getCreatorCentreRelay());
+    }
+
+    public function provideTestAddCreatorRelay(): \Generator
+    {
+        yield 'test' => [BeneficiaireFactory::new()];
+        yield 'test2' => [MembreFactory::new()];
     }
 }


### PR DESCRIPTION
[Ticket](https://trello.com/c/1wNIizZt/4316-3-admin-pourquoi-sur-les-membres-les-cr%C3%A9%C3%A9-par-sont-vides)
