### PR TITLE
ETQB, sur le site du CFN au niveau des documents je vois un tooltip "passer partagé" ou "passer privé"

### DIFF
--- a/assets/controllers/ajax_toggle_controller.js
+++ b/assets/controllers/ajax_toggle_controller.js
@@ -1,12 +1,14 @@
 import {Controller} from '@hotwired/stimulus';
 import {axiosInstance} from '../js/helpers/axios';
+import {Tooltip} from "bootstrap-next";
 
 export default class extends Controller {
   static values = {url: String};
-  static targets = ['icon']
+  static targets = ['icon', 'switch']
 
   toggle(event) {
     const icons = this.iconTargets;
+    const toggleSwitch = this.switchTarget;
 
     axiosInstance.patch(this.urlValue)
       .then(function () {
@@ -15,6 +17,12 @@ export default class extends Controller {
             (cssClass) => icon.classList.toggle(cssClass)
           )
         )
+
+        const tooltip = Tooltip.getInstance(toggleSwitch)
+        const currentTooltip = tooltip._config.title;
+        tooltip._config.title = toggleSwitch.dataset.nextToggleTooltip;
+        toggleSwitch.dataset.nextToggleTooltip = currentTooltip
+        tooltip.update();
       })
       .catch(() => {
         event.target.classList.toggle('bg-red');

--- a/templates/v2/vault/components/_toggle_visibility_button.html.twig
+++ b/templates/v2/vault/components/_toggle_visibility_button.html.twig
@@ -8,7 +8,12 @@
 
     >
     </i>
-    <div class="form-check form-switch form-switch-vault-visibility mx-2">
+    <div class="form-check form-switch form-switch-vault-visibility mx-2"
+         data-next-toggle-tooltip='{{ private ? 'switch_private'|trans : 'switch_shared'|trans }}'
+        {{ stimulus_target('ajax-toggle', 'switch')|stimulus_controller('tooltip', {
+            title: private ? 'switch_shared'|trans : 'switch_private'|trans,
+        }) }}
+    >
         <input type="checkbox"
                class="form-check-input form-check-vault-visibility text-white me-0"
                {{ stimulus_action('ajax-toggle', 'toggle') }}


### PR DESCRIPTION
[Ticket](https://trello.com/c/Qw0jZtpn/4480-3-etqb-sur-le-site-du-cfn-au-niveau-des-documents-je-vois-un-tooltip-passer-partag%C3%A9-ou-passer-priv%C3%A9-comme-sur-lappli)
