### PR TITLE
[2.57.0] ETQB, sur le site du CFN au niveau des documents je vois un tooltip "passer partagé" ou "passer privé" 

### DIFF
--- a/assets/controllers/ajax_toggle_controller.js
+++ b/assets/controllers/ajax_toggle_controller.js
@@ -1,12 +1,14 @@
 import {Controller} from '@hotwired/stimulus';
 import {axiosInstance} from '../js/helpers/axios';
+import {Tooltip} from "bootstrap-next";
 
 export default class extends Controller {
   static values = {url: String};
-  static targets = ['icon']
+  static targets = ['icon', 'switch']
 
   toggle(event) {
     const icons = this.iconTargets;
+    const toggleSwitch = this.switchTarget;
 
     axiosInstance.patch(this.urlValue)
       .then(function () {
@@ -15,6 +17,12 @@ export default class extends Controller {
             (cssClass) => icon.classList.toggle(cssClass)
           )
         )
+
+        const tooltip = Tooltip.getInstance(toggleSwitch)
+        const currentTooltip = tooltip._config.title;
+        tooltip._config.title = toggleSwitch.dataset.nextToggleTooltip;
+        toggleSwitch.dataset.nextToggleTooltip = currentTooltip
+        tooltip.update();
       })
       .catch(() => {
         event.target.classList.toggle('bg-red');

--- a/assets/controllers/ajax_toggle_controller.js
+++ b/assets/controllers/ajax_toggle_controller.js
@@ -13,19 +13,36 @@ export default class extends Controller {
     axiosInstance.patch(this.urlValue)
       .then(function () {
         icons.forEach(
-          (icon) => icon.dataset.toggleClasses.split(' ').forEach(
-            (cssClass) => icon.classList.toggle(cssClass)
-          )
+          (icon) => {
+              updateTooltipTitle(icon);
+              icon.dataset.toggleClasses.split(' ').forEach(
+                  (cssClass) => icon.classList.toggle(cssClass)
+              );
+          }
         )
 
-        const tooltip = Tooltip.getInstance(toggleSwitch)
-        const currentTooltip = tooltip._config.title;
-        tooltip._config.title = toggleSwitch.dataset.nextToggleTooltip;
-        toggleSwitch.dataset.nextToggleTooltip = currentTooltip
-        tooltip.update();
+        updateTooltipTitle(toggleSwitch);
       })
       .catch(() => {
         event.target.classList.toggle('bg-red');
       })
   }
+}
+
+function updateTooltipTitle(element) {
+    const tooltip = Tooltip.getInstance(element);
+    const nextTooltipTitle = element.dataset.nextToggleTooltip;
+
+    if (tooltip) {
+        const currentTooltip = tooltip._config.title;
+        tooltip._config.title = nextTooltipTitle;
+        element.dataset.nextToggleTooltip = currentTooltip
+        tooltip.update();
+    } else {
+        new Tooltip(element, {
+            trigger: 'hover',
+            container: element.parentNode,
+            title: nextTooltipTitle,
+        });
+    }
 }

--- a/templates/v2/vault/components/_toggle_visibility_button.html.twig
+++ b/templates/v2/vault/components/_toggle_visibility_button.html.twig
@@ -1,10 +1,11 @@
 <div class="d-flex justify-content-center align-items-center"
     {{ stimulus_controller('ajax-toggle', {'url': url })}}
 >
-    <i class="fas fa-lock{{ private ? ' text-primary' : '-open text-light-grey' }} me-2 green-tooltip"
+    <i class="fas fa-lock{{ private ? ' text-primary' : '-open text-light-grey' }} me-2"
        {{ stimulus_target('ajax-toggle', 'icon') }}
        data-toggle-classes='text-light-grey fa-lock-open fa-lock'
-            {{ stimulus_controller('tooltip', {title: 'private'|trans}) }}
+       data-next-toggle-tooltip='{{ private ? '' : 'private'|trans }}'
+        {{ stimulus_controller('tooltip', {title: private ? 'private'|trans : ''}) }}
 
     >
     </i>
@@ -20,10 +21,11 @@
                 {{ private ? '' : 'checked' }}
         >
     </div>
-    <i class="fas fa-share {{ private ? 'text-light-grey' : 'text-green' }} green-tooltip"
+    <i class="fas fa-share {{ private ? 'text-light-grey' : 'text-green' }}"
         {{ stimulus_target('ajax-toggle', 'icon') }}
        data-toggle-classes='text-light-grey text-green'
-            {{ stimulus_controller('tooltip', {title: 'shared'|trans}) }}
+       data-next-toggle-tooltip='{{ private ? 'shared'|trans : '' }}'
+        {{ stimulus_controller('tooltip', {title: private ? '' : 'shared'|trans}) }}
     >
     </i>
 </div>

--- a/templates/v2/vault/components/_toggle_visibility_button.html.twig
+++ b/templates/v2/vault/components/_toggle_visibility_button.html.twig
@@ -8,7 +8,12 @@
 
     >
     </i>
-    <div class="form-check form-switch form-switch-vault-visibility mx-2">
+    <div class="form-check form-switch form-switch-vault-visibility mx-2"
+         data-next-toggle-tooltip='{{ private ? 'switch_private'|trans : 'switch_shared'|trans }}'
+        {{ stimulus_target('ajax-toggle', 'switch')|stimulus_controller('tooltip', {
+            title: private ? 'switch_shared'|trans : 'switch_private'|trans,
+        }) }}
+    >
         <input type="checkbox"
                class="form-check-input form-check-vault-visibility text-white me-0"
                {{ stimulus_action('ajax-toggle', 'toggle') }}


### PR DESCRIPTION
[Ticket](https://trello.com/c/Qw0jZtpn/4480-3-etqb-sur-le-site-du-cfn-au-niveau-des-documents-je-vois-un-tooltip-passer-partag%C3%A9-ou-passer-priv%C3%A9-comme-sur-lappli)
