### PR TITLE
ETQU, Lorsque je déplace un élément dans un dossier partagé, il conserve sa visibilité + ETQU, Quand je suis dans un dossier privé, je vois uniquement le cadenas avec un tooltip / Quand je suis dans un dossier partagé, je vois le bouton switch qui permet de toggle la visibilité

### DIFF
--- a/src/Admin/ContactAdmin.php
+++ b/src/Admin/ContactAdmin.php
@@ -154,7 +154,7 @@ class ContactAdmin extends AbstractAdmin
                 'label' => 'Créé par (client)',
             ])
             ->add('createdAt', null, ['label' => 'Créé le'])
-            ->add('isPrivate', null, ['label' => 'Accès'])
+            ->add('isPrivateToString', null, ['label' => 'Accès'])
             ->add('beneficiaire.user.canada', null, ['label' => 'Canada']);
     }
 

--- a/src/Admin/DocumentAdmin.php
+++ b/src/Admin/DocumentAdmin.php
@@ -153,7 +153,7 @@ class DocumentAdmin extends AbstractAdmin
             ->add('creatorCentre', null, ['label' => 'Déposé par (centre)'])
             ->add('creatorClient', null, ['label' => 'Déposé par (client)'])
             ->add('createdAt', null, ['label' => 'Créé le'])
-            ->add('isPrivate', null, ['label' => 'Accès'])
+            ->add('isPrivateToString', null, ['label' => 'Accès'])
             ->add('dossier.id', null, ['label' => 'Id dossier'])
             ->add('dossier.nom', null, ['label' => 'Nom du dossier'])
             ->add('beneficiaire.user.canada', null, ['label' => 'Canada']);

--- a/src/Admin/DossierAdmin.php
+++ b/src/Admin/DossierAdmin.php
@@ -80,7 +80,7 @@ class DossierAdmin extends AbstractAdmin
             ->addIdentifier('id', null, ['route' => ['name' => 'edit']])
             ->addIdentifier('beneficiaire', null, ['route' => ['name' => 'edit']])
             ->addIdentifier('nom', null, ['route' => ['name' => 'edit']])
-            ->add('isPrivate', null, ['label' => 'Accès'])
+            ->add('isPrivateToString', null, ['label' => 'Accès'])
             ->addIdentifier('createdAt', null, ['route' => ['name' => 'edit']])
             ->add('dossierParent.id', null, ['label' => 'Id dossier parent'])
             ->add('beneficiaire.user.canada', null, ['label' => 'Canada']);

--- a/src/Admin/EvenementAdmin.php
+++ b/src/Admin/EvenementAdmin.php
@@ -157,7 +157,7 @@ class EvenementAdmin extends AbstractAdmin
                 'label' => 'Créé par (client)',
             ])
             ->add('createdAt', null, ['label' => 'Créé le'])
-            ->add('isPrivate', null, ['label' => 'Accès'])
+            ->add('isPrivateToString', null, ['label' => 'Accès'])
             ->add('beneficiaire.user.canada', null, ['label' => 'Canada']);
     }
 

--- a/src/Admin/NoteAdmin.php
+++ b/src/Admin/NoteAdmin.php
@@ -160,7 +160,7 @@ class NoteAdmin extends AbstractAdmin
                 'label' => 'Créé par (client)',
             ])
             ->add('createdAt', null, ['label' => 'Créé le'])
-            ->add('isPrivate', null, ['label' => 'Accès'])
+            ->add('isPrivateToString', null, ['label' => 'Accès'])
             ->add('beneficiaire.user.canada', null, ['label' => 'Canada']);
     }
 

--- a/src/Entity/Document.php
+++ b/src/Entity/Document.php
@@ -393,9 +393,10 @@ class Document extends DonneePersonnelle implements FolderableEntityInterface
     public function move(?Dossier $parentFolder): void
     {
         $this->setDossier($parentFolder);
-        if ($parentFolder) {
-            $parentFolder->addDocument($this);
-            $this->setBPrive($parentFolder->getBPrive());
+        $parentFolder->addDocument($this);
+
+        if ($parentFolder?->isPrivate()) {
+            $this->setBPrive(true);
         }
     }
 }

--- a/src/Entity/Document.php
+++ b/src/Entity/Document.php
@@ -390,6 +390,12 @@ class Document extends DonneePersonnelle implements FolderableEntityInterface
     }
 
     #[\Override]
+    public function canToggleVisibility(): bool
+    {
+        return !$this->hasParentFolder() || !$this->getDossier()->isPrivate();
+    }
+
+    #[\Override]
     public function move(?Dossier $parentFolder): void
     {
         $this->setDossier($parentFolder);

--- a/src/Entity/Document.php
+++ b/src/Entity/Document.php
@@ -393,10 +393,10 @@ class Document extends DonneePersonnelle implements FolderableEntityInterface
     public function move(?Dossier $parentFolder): void
     {
         $this->setDossier($parentFolder);
-        $parentFolder->addDocument($this);
+        $parentFolder?->addDocument($this);
 
         if ($parentFolder?->isPrivate()) {
-            $this->setBPrive(true);
+            $this->makePrivate();
         }
     }
 }

--- a/src/Entity/DonneePersonnelle.php
+++ b/src/Entity/DonneePersonnelle.php
@@ -198,13 +198,25 @@ abstract class DonneePersonnelle implements \JsonSerializable, \Stringable
         return $this->creators;
     }
 
-    public function toggleVisibility(): void
+    public function setPrivate(bool $isPrivate): static
     {
-        $this->setBPrive(!$this->getBPrive());
+        $this->bPrive = $isPrivate;
+
+        return $this;
     }
 
     public function isPrivate(): bool
     {
-        return true === $this->getBPrive();
+        return $this->bPrive;
+    }
+
+    public function toggleVisibility(): void
+    {
+        $this->setPrivate(!$this->isPrivate());
+    }
+
+    public function makePrivate(): void
+    {
+        $this->setPrivate(true);
     }
 }

--- a/src/Entity/DonneePersonnelle.php
+++ b/src/Entity/DonneePersonnelle.php
@@ -118,7 +118,7 @@ abstract class DonneePersonnelle implements \JsonSerializable, \Stringable
     /**
      * Dans le cadre de l'admin.
      */
-    public function isPrivate(): string
+    public function isPrivateToString(): string
     {
         if ($this->bPrive) {
             return 'privé';
@@ -201,5 +201,10 @@ abstract class DonneePersonnelle implements \JsonSerializable, \Stringable
     public function toggleVisibility(): void
     {
         $this->setBPrive(!$this->getBPrive());
+    }
+
+    public function isPrivate(): bool
+    {
+        return true === $this->getBPrive();
     }
 }

--- a/src/Entity/Dossier.php
+++ b/src/Entity/Dossier.php
@@ -198,15 +198,23 @@ class Dossier extends DonneePersonnelle implements FolderableEntityInterface
     #[\Override]
     public function toggleVisibility(): void
     {
-        $this->setBPrive(!$this->getBPrive());
+        $this->setPrivate(!$this->isPrivate());
 
         array_map(
             fn (DonneePersonnelle $personalData) => $personalData->toggleVisibility(),
             [
-                ...$this->getSousDossiers()->filter(fn (Dossier $dossier) => $dossier->getBPrive() !== $this->getBPrive())->toArray(),
-                ...$this->getDocuments()->filter(fn (Document $document) => $document->getBPrive() !== $this->getBPrive())->toArray(),
+                ...$this->getSousDossiers()->filter(fn (Dossier $dossier) => $dossier->isPrivate() !== $this->isPrivate())->toArray(),
+                ...$this->getDocuments()->filter(fn (Document $document) => $document->isPrivate() !== $this->isPrivate())->toArray(),
             ],
         );
+    }
+
+    #[\Override]
+    public function makePrivate(): void
+    {
+        if (!$this->isPrivate()) {
+            $this->toggleVisibility();
+        }
     }
 
     #[\Override]
@@ -222,8 +230,8 @@ class Dossier extends DonneePersonnelle implements FolderableEntityInterface
 
         if ($parentFolder && $parentFolder !== $this) {
             $parentFolder->addSousDossier($this);
-            if ($parentFolder->isPrivate() && !$this->isPrivate()) {
-                $this->toggleVisibility();
+            if ($parentFolder->isPrivate()) {
+                $this->makePrivate();
             }
         }
     }

--- a/src/Entity/Dossier.php
+++ b/src/Entity/Dossier.php
@@ -224,6 +224,12 @@ class Dossier extends DonneePersonnelle implements FolderableEntityInterface
     }
 
     #[\Override]
+    public function canToggleVisibility(): bool
+    {
+        return !$this->hasParentFolder() || !$this->getDossierParent()->isPrivate();
+    }
+
+    #[\Override]
     public function move(?Dossier $parentFolder): void
     {
         $this->setDossierParent($parentFolder);

--- a/src/Entity/Dossier.php
+++ b/src/Entity/Dossier.php
@@ -222,7 +222,7 @@ class Dossier extends DonneePersonnelle implements FolderableEntityInterface
 
         if ($parentFolder && $parentFolder !== $this) {
             $parentFolder->addSousDossier($this);
-            if ($parentFolder->getBPrive() !== $this->getBPrive()) {
+            if ($parentFolder->isPrivate() && !$this->isPrivate()) {
                 $this->toggleVisibility();
             }
         }

--- a/src/Entity/Interface/FolderableEntityInterface.php
+++ b/src/Entity/Interface/FolderableEntityInterface.php
@@ -9,4 +9,6 @@ interface FolderableEntityInterface
     public function hasParentFolder(): bool;
 
     public function move(?Dossier $parentFolder): void;
+
+    public function canToggleVisibility(): bool;
 }

--- a/src/Security/VoterV2/PersonalDataVoter.php
+++ b/src/Security/VoterV2/PersonalDataVoter.php
@@ -60,7 +60,7 @@ class PersonalDataVoter extends Voter
 
     private function canToggleVisibility(User $user, DonneePersonnelle $subject): bool
     {
-        if ($subject instanceof FolderableEntityInterface && $subject->hasParentFolder()) {
+        if ($subject instanceof FolderableEntityInterface && !$subject->canToggleVisibility()) {
             return false;
         }
 

--- a/templates/v2/vault/document/_card.html.twig
+++ b/templates/v2/vault/document/_card.html.twig
@@ -18,11 +18,13 @@
         }) }}
     </td>
     <td class="bg-white borderless w-25 align-middle">
-        {% if app.user.isBeneficiaire and not document.dossier %}
+        {% if app.user.isBeneficiaire and document.canToggleVisibility %}
             {{ include('v2/vault/components/_toggle_visibility_button.html.twig', {
                 'url': path('document_toggle_visibility', {'id': document.id}),
                 'private': document.bPrive,
             }) }}
+        {% else %}
+            <i class="fas fa-lock text-primary me-2" {{ stimulus_controller('tooltip', {title: 'private'|trans}) }}></i>
         {% endif %}
     </td>
     <td class="bg-white borderless text-end pe-3 pe-sm-4 align-middle" {{ stimulus_controller('dropdown-menu') }}>

--- a/templates/v2/vault/folder/_card.html.twig
+++ b/templates/v2/vault/folder/_card.html.twig
@@ -25,11 +25,13 @@
         {% endif %}
     </td>
     <td class="bg-white borderless w-25 align-middle">
-        {% if app.user.isBeneficiaire and not folder.dossierParent %}
+        {% if app.user.isBeneficiaire and folder.canToggleVisibility %}
             {{ include('v2/vault/components/_toggle_visibility_button.html.twig', {
                 'url': path('folder_toggle_visibility', {'id': folder.id}),
                 'private': folder.bPrive,
             }) }}
+        {% else %}
+            <i class="fas fa-lock text-primary me-2" {{ stimulus_controller('tooltip', {title: 'private'|trans}) }}></i>
         {% endif %}
     </td>
     <td class="bg-white borderless text-end pe-3 pe-sm-4 align-middle" {{ stimulus_controller('dropdown-menu') }}>

--- a/tests/v2/Controller/DocumentController/SwitchPrivateTest.php
+++ b/tests/v2/Controller/DocumentController/SwitchPrivateTest.php
@@ -50,20 +50,38 @@ class SwitchPrivateTest extends AbstractControllerTest implements TestRouteInter
 
     public function provideTestCanNotSwitchPrivateWithParentFolder(): ?\Generator
     {
-        yield 'Should return 403 status code when authenticated as beneficiaire and document has parent folder' => [
+        yield 'Should return 403 status code when authenticated as beneficiaire and document has private parent folder' => [
             BeneficiaryFixture::BENEFICIARY_MAIL,
+            true,
+            403,
         ];
-        yield 'Should return 403 status code when authenticated as member with relay in common and document has parent folder' => [
+        yield 'Should redirect when authenticated as beneficiaire and document has shared parent folder' => [
+            BeneficiaryFixture::BENEFICIARY_MAIL,
+            false,
+            302,
+        ];
+        yield 'Should return 403 status code when authenticated as member with relay in common and document has private parent folder' => [
             MemberFixture::MEMBER_MAIL_WITH_RELAYS_SHARED_WITH_BENEFICIARIES,
+            true,
+            403,
+        ];
+        yield 'Should redirect when authenticated as member with relay in common and document has shared parent folder' => [
+            MemberFixture::MEMBER_MAIL_WITH_RELAYS_SHARED_WITH_BENEFICIARIES,
+            false,
+            302,
         ];
     }
 
     /** @dataProvider provideTestCanNotSwitchPrivateWithParentFolder */
-    public function testCanNotSwitchPrivateWithParentFolder(string $userMail): void
+    public function testCanNotSwitchPrivateWithParentFolder(string $userMail, bool $isPrivateParentFolder, int $statusCode): void
     {
         $beneficiary = BeneficiaireFactory::findByEmail(BeneficiaryFixture::BENEFICIARY_MAIL)->object();
-        $document = DocumentFactory::findOrCreate(['beneficiaire' => $beneficiary, 'dossier' => FolderFactory::random()])->object();
+        $document = DocumentFactory::findOrCreate([
+            'bPrive' => false,
+            'beneficiaire' => $beneficiary,
+            'dossier' => FolderFactory::random(['bPrive' => $isPrivateParentFolder]),
+        ])->object();
 
-        $this->assertRoute(sprintf(self::URL, $document->getId()), 403, $userMail);
+        $this->assertRoute(sprintf(self::URL, $document->getId()), $statusCode, $userMail);
     }
 }


### PR DESCRIPTION
[Ticket](https://trello.com/c/2UdEAiz6/5117-3-etqu-lorsque-je-d%C3%A9place-un-%C3%A9l%C3%A9ment-dans-un-dossier-partag%C3%A9-il-conserve-sa-visibilit%C3%A9)
[Ticket](https://trello.com/c/OwiDkgwk/5118-5-etqu-quand-je-suis-dans-un-dossier-priv%C3%A9-je-vois-uniquement-le-cadenas-avec-un-tooltip-quand-je-suis-dans-un-dossier-partag%C3%A9-j)
