### PR TITLE
[2.65.1] ETQP quand je consulte un CFN, je ne dois pas voir l'icone cadenas "privé" sur les données persos partagées

### DIFF
--- a/templates/v2/vault/document/_card.html.twig
+++ b/templates/v2/vault/document/_card.html.twig
@@ -18,13 +18,15 @@
         }) }}
     </td>
     <td class="bg-white borderless w-25 align-middle">
-        {% if app.user.isBeneficiaire and document.canToggleVisibility %}
-            {{ include('v2/vault/components/_toggle_visibility_button.html.twig', {
-                'url': path('document_toggle_visibility', {'id': document.id}),
-                'private': document.bPrive,
-            }) }}
-        {% else %}
-            <i class="fas fa-lock text-primary me-2" {{ stimulus_controller('tooltip', {title: 'private'|trans}) }}></i>
+        {% if app.user.isBeneficiaire %}
+            {% if document.canToggleVisibility %}
+                {{ include('v2/vault/components/_toggle_visibility_button.html.twig', {
+                    'url': path('document_toggle_visibility', {'id': document.id}),
+                    'private': document.bPrive,
+                }) }}
+            {% else %}
+                <i class="fas fa-lock text-primary me-2" {{ stimulus_controller('tooltip', {title: 'private'|trans}) }}></i>
+            {% endif %}
         {% endif %}
     </td>
     <td class="bg-white borderless text-end pe-3 pe-sm-4 align-middle" {{ stimulus_controller('dropdown-menu') }}>

--- a/templates/v2/vault/folder/_card.html.twig
+++ b/templates/v2/vault/folder/_card.html.twig
@@ -25,13 +25,15 @@
         {% endif %}
     </td>
     <td class="bg-white borderless w-25 align-middle">
-        {% if app.user.isBeneficiaire and folder.canToggleVisibility %}
-            {{ include('v2/vault/components/_toggle_visibility_button.html.twig', {
-                'url': path('folder_toggle_visibility', {'id': folder.id}),
-                'private': folder.bPrive,
-            }) }}
-        {% else %}
-            <i class="fas fa-lock text-primary me-2" {{ stimulus_controller('tooltip', {title: 'private'|trans}) }}></i>
+        {% if app.user.isBeneficiaire %}
+            {% if folder.canToggleVisibility %}
+                {{ include('v2/vault/components/_toggle_visibility_button.html.twig', {
+                    'url': path('folder_toggle_visibility', {'id': folder.id}),
+                    'private': folder.bPrive,
+                }) }}
+            {% else %}
+                <i class="fas fa-lock text-primary me-2" {{ stimulus_controller('tooltip', {title: 'private'|trans}) }}></i>
+            {% endif %}
         {% endif %}
     </td>
     <td class="bg-white borderless text-end pe-3 pe-sm-4 align-middle" {{ stimulus_controller('dropdown-menu') }}>


### PR DESCRIPTION
[Ticket](https://trello.com/c/PTzLrWQy/5162-1-etqp-quand-je-consulte-un-cfn-je-ne-dois-pas-voir-licone-cadenas-priv%C3%A9-sur-les-donn%C3%A9es-persos-partag%C3%A9es)
