### PR TITLE
[2.67.0] ETQU, si je tente d'affilier un suivi RP à un CFN qui possède déjà une liaison avec un autre suivi de la même structure sur RP, je dois voir un message d'erreur

### DIFF
--- a/src/Api/State/BeneficiaryStateProcessor.php
+++ b/src/Api/State/BeneficiaryStateProcessor.php
@@ -19,6 +19,7 @@ use App\ServiceV2\Helper\RelayAssignationHelper;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 readonly class BeneficiaryStateProcessor implements ProcessorInterface
 {
@@ -42,6 +43,9 @@ readonly class BeneficiaryStateProcessor implements ProcessorInterface
 
         if ($data instanceof LinkBeneficiaryDto && $operation instanceof Patch && $client) {
             $beneficiary = $this->beneficiaryRepository->find($uriVariables['id']);
+            if (!$beneficiary->getExternalLinksForClient($client)->isEmpty()) {
+                throw new UnprocessableEntityHttpException('This beneficiary already has a link for this client.');
+            }
             $this->createExternalLink($data, $client, $beneficiary);
 
             return $beneficiary;

--- a/tests/v2/API/v3/Beneficiary/AddExternalLinkTest.php
+++ b/tests/v2/API/v3/Beneficiary/AddExternalLinkTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\v2\API\v3\Beneficiary;
 
+use App\DataFixtures\v2\BeneficiaryFixture;
 use App\Repository\ClientRepository;
 use App\Tests\Factory\BeneficiaireFactory;
 use App\Tests\v2\API\v3\AbstractApiTest;
@@ -45,5 +46,28 @@ class AddExternalLinkTest extends AbstractApiTest
         $beneficiaireCentre = $beneficiary->getBeneficiairesCentres()->first();
         $this->assertNotNull($beneficiaireCentre);
         $this->assertNotNull($beneficiary->getExternalLinksForClient($client)->first());
+    }
+
+    public function testShouldNotAddExternalLink(): void
+    {
+        $beneficiary = BeneficiaireFactory::findByEmail(BeneficiaryFixture::BENEFICIARY_WITH_CLIENT_LINK);
+        $client = $this->clientRepository->findOneBy(['nom' => 'reconnect_pro']);
+        $this->assertNotNull($beneficiary->getExternalLinksForClient($client)->first());
+
+        $this->assertEndpoint(
+            'reconnect_pro',
+            sprintf('/beneficiaries/%s/add-external-link', $beneficiary->getId()),
+            'PATCH',
+            422,
+            [
+                '@context' => '/api/contexts/Error',
+                '@type' => 'hydra:Error',
+            ],
+            [
+                'distant_id' => 1200,
+                'external_center' => 42,
+                'external_pro_id' => 4972,
+            ]
+        );
     }
 }


### PR DESCRIPTION
[Ticket](https://trello.com/c/LfVVq6vH/5160-8-etqu-si-je-tente-daffilier-un-suivi-rp-%C3%A0-un-cfn-qui-poss%C3%A8de-d%C3%A9j%C3%A0-une-liaison-avec-un-autre-suivi-de-la-m%C3%AAme-structure-sur-rp-j)
