### PR TITLE
[Release] [Cleaned] ETQB, je vois un trait de couleur à gauche de l'item correspondant à l'état privé ou partagé de mon dossier ou document 

### DIFF
--- a/assets/controllers/ajax_toggle_controller.js
+++ b/assets/controllers/ajax_toggle_controller.js
@@ -4,28 +4,32 @@ import {Tooltip} from "bootstrap-next";
 
 export default class extends Controller {
   static values = {url: String};
-  static targets = ['icon', 'switch']
+  static targets = ['icon', 'switch', 'card'];
 
   toggle(event) {
     const icons = this.iconTargets;
     const toggleSwitch = this.switchTarget;
+    const card = this.cardTarget;
 
     axiosInstance.patch(this.urlValue)
       .then(function () {
         icons.forEach(
           (icon) => {
-              updateTooltipTitle(icon);
-              icon.dataset.toggleClasses.split(' ').forEach(
-                  (cssClass) => icon.classList.toggle(cssClass)
-              );
+            updateTooltipTitle(icon);
+            icon.dataset.toggleClasses.split(' ').forEach(
+              (cssClass) => icon.classList.toggle(cssClass)
+            );
           }
-        )
+        );
 
         updateTooltipTitle(toggleSwitch);
+          card.dataset.toggleClasses.split(' ').forEach(
+          (cssClass) => card.classList.toggle(cssClass)
+        );
       })
       .catch(() => {
         event.target.classList.toggle('bg-red');
-      })
+      });
   }
 }
 

--- a/assets/css/appV2/table.scss
+++ b/assets/css/appV2/table.scss
@@ -12,6 +12,24 @@ th:last-child{
   border-radius: 0 10px 10px 0;
 }
 
+.personal-data-card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 5px;
+  border-radius: 0 0 0 30px;
+  background-color: theme-color('primary');
+}
+.shared::before {
+  background-color: theme-color('green');
+}
+
+.private::before {
+  background-color: theme-color('primary');
+}
+
 .borderless{
   border: none;
 }

--- a/templates/v2/vault/components/_toggle_visibility_button.html.twig
+++ b/templates/v2/vault/components/_toggle_visibility_button.html.twig
@@ -1,6 +1,4 @@
-<div class="d-flex justify-content-center align-items-center"
-    {{ stimulus_controller('ajax-toggle', {'url': url })}}
->
+<div class="d-flex justify-content-center align-items-center">
     <i class="fas fa-lock{{ private ? ' text-primary' : '-open text-light-grey' }} me-2"
        {{ stimulus_target('ajax-toggle', 'icon') }}
        data-toggle-classes='text-light-grey fa-lock-open fa-lock'

--- a/templates/v2/vault/contact/_card.html.twig
+++ b/templates/v2/vault/contact/_card.html.twig
@@ -1,5 +1,10 @@
-<tr class="text-primary text-center align-middle">
-    <td class="bg-white borderless p-0">
+<tr class="text-primary text-center align-middle"
+    {{ stimulus_controller('ajax-toggle', {'url': path('contact_toggle_visibility', {'id': contact.id}) })}}
+>
+    <td class="bg-white borderless p-0 personal-data-card position-relative {{ contact.bPrive ? 'private' : 'shared' }}"
+        {{ stimulus_target('ajax-toggle', 'card') }}
+        data-toggle-classes="shared private"
+    >
         <a href="{{ path('contact_detail', {'id': contact.id}) }}" class="text-decoration-none text-primary d-block py-2 h-100">
             {{ contact.nom|upper }}
         </a>

--- a/templates/v2/vault/document/_card.html.twig
+++ b/templates/v2/vault/document/_card.html.twig
@@ -1,5 +1,12 @@
-<tr class="text-primary text-center draggable" data-id="{{ document.id }}" data-type="document" {{ stimulus_controller('modal') }}>
-    <td class="bg-white borderless text-start align-middle">
+<tr class="text-primary text-center draggable position-relative"
+    data-id="{{ document.id }}"
+    data-type="document"
+    {{ stimulus_controller('ajax-toggle', {'url': path('document_toggle_visibility', {'id': document.id}) })|stimulus_controller('modal') }}
+>
+    <td class="bg-white borderless text-start align-middle  personal-data-card position-relative {{ document.bPrive ? 'private' : 'shared' }}"
+        {{ stimulus_target('ajax-toggle', 'card') }}
+        data-toggle-classes="shared private"
+    >
         <button class="btn p-0" {{ stimulus_action('modal', 'open') }}>
             {{ include('v2/vault/document/_thumbnail.html.twig', {'document': document}) }}
         </button>

--- a/templates/v2/vault/event/_card.html.twig
+++ b/templates/v2/vault/event/_card.html.twig
@@ -1,5 +1,10 @@
-<tr class="text-primary text-center align-middle">
-    <td class="bg-white borderless text-start p-0 w-100 me-auto">
+<tr class="text-primary text-center align-middle"
+    {{ stimulus_controller('ajax-toggle', {'url': path('event_toggle_visibility', {'id': event.id}) })}}
+>
+    <td class="bg-white borderless text-start p-0 w-100 me-auto  personal-data-card position-relative {{ event.bPrive ? 'private' : 'shared' }}"
+        {{ stimulus_target('ajax-toggle', 'card') }}
+        data-toggle-classes="shared private"
+    >
         <a href="{{ path('event_detail', {'id': event.id}) }}" class="text-decoration-none d-block h-100 ps-3 py-2">
             <span class="bold text-primary">
                 {% if 'now'|date('d/m/Y') == event.date|date('d/m/Y') %}

--- a/templates/v2/vault/folder/_card.html.twig
+++ b/templates/v2/vault/folder/_card.html.twig
@@ -1,7 +1,11 @@
-<tr class="text-primary text-center draggable droppable"
-        {{ stimulus_target('drag_n_drop', 'folder') }} data-id="{{ folder.id }}"
+<tr class="text-primary text-center draggable droppable position-relative"
+    {{ stimulus_controller('ajax-toggle', {'url': path('folder_toggle_visibility', {'id': folder.id}) })|stimulus_target('drag_n_drop', 'folder') }}
+    data-id="{{ folder.id }}"
 >
-    <td class="bg-white borderless text-start align-middle">
+    <td class="bg-white borderless text-start align-middle  personal-data-card position-relative {{ folder.bPrive ? 'private' : 'shared' }}"
+        {{ stimulus_target('ajax-toggle', 'card') }}
+        data-toggle-classes="shared private"
+    >
         <a href="{{ path('folder', {'id': folder.id}) }}" class="text-decoration-none text-primary d-block">
             <i class="fa fa-fw fa-folder-open fa-3x"></i>
         </a>

--- a/templates/v2/vault/note/_card.html.twig
+++ b/templates/v2/vault/note/_card.html.twig
@@ -1,5 +1,10 @@
-<tr class="text-primary text-center align-middle">
-    <td class="bg-white borderless text-start p-0 w-100 me-auto">
+<tr class="text-primary text-center align-middle"
+        {{ stimulus_controller('ajax-toggle', {'url': path('note_toggle_visibility', {'id': note.id}) })}}
+>
+    <td class="bg-white borderless text-start p-0 w-100 me-auto personal-data-card position-relative {{ note.bPrive ? 'private' : 'shared' }}"
+        {{ stimulus_target('ajax-toggle', 'card') }}
+        data-toggle-classes="shared private"
+    >
         <a href="{{ path('note_detail', {'id': note.id}) }}" class="text-decoration-none text-primary d-block py-2 ps-3">
             <span>{{ note.nom }}</span>
             <br>


### PR DESCRIPTION
Added new `leftBar` target to the `ajax_toggle_controller.js` and associated logic to update its color. Modified `_toggle_visibility_button.html.twig` and `_card.html.twig` for better integration and updated styles to visually differentiate shared and not-shared states.

[Ticket](https://trello.com/c/fe8BxvI8/5049-3-etqb-je-vois-un-trait-de-couleur-%C3%A0-gauche-de-litem-correspondant-%C3%A0-l%C3%A9tat-priv%C3%A9-ou-partag%C3%A9-de-mon-dossier-ou-document)
