### PR TITLE
ETQP, quand je déplace un dossier ou un document, je devrais voir uniquement l'arborescence des dossiers partagés pour y déplacer mon élément

### DIFF
--- a/src/Entity/Beneficiaire.php
+++ b/src/Entity/Beneficiaire.php
@@ -905,6 +905,14 @@ class Beneficiaire extends Subject implements UserWithCentresInterface, ClientRe
     /**
      * @return Collection<int, Dossier>
      */
+    public function getSharedRootFolders(): Collection
+    {
+        return $this->getRootFolders()->filter(fn (Dossier $folder) => !$folder->isPrivate());
+    }
+
+    /**
+     * @return Collection<int, Dossier>
+     */
     public function getRootDocuments(): Collection
     {
         $criteria = Criteria::create()->andWhere(Criteria::expr()->isNull('dossier'));

--- a/src/ManagerV2/FolderManager.php
+++ b/src/ManagerV2/FolderManager.php
@@ -46,7 +46,7 @@ class FolderManager
     {
         return $this->getUser() === $beneficiary->getUser()
             ? $beneficiary->getRootFolders()
-            : $beneficiary->getPrivateRootFolders();
+            : $beneficiary->getSharedRootFolders();
     }
 
     public function toggleVisibility(Dossier $folder): void

--- a/tests/v2/Manager/FolderManager/getRootFoldersTest.php
+++ b/tests/v2/Manager/FolderManager/getRootFoldersTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Tests\v2\Manager\FolderManager;
+
+use App\DataFixtures\v2\BeneficiaryFixture;
+use App\DataFixtures\v2\MemberFixture;
+use App\ManagerV2\FolderManager;
+use App\Tests\Factory\BeneficiaireFactory;
+use App\Tests\v2\AuthenticatedKernelTestCase;
+
+class getRootFoldersTest extends AuthenticatedKernelTestCase
+{
+    public function testBeneficiaryShouldGetAllRootFolders()
+    {
+        self::ensureKernelShutdown();
+        $beneficiary = BeneficiaireFactory::findByEmail(BeneficiaryFixture::BENEFICIARY_MAIL)->object();
+        $this->loginUser(BeneficiaryFixture::BENEFICIARY_MAIL);
+        $manager = static::getContainer()->get(FolderManager::class);
+        $this->assertEquals($beneficiary->getRootFolders(), $manager->getRootFolders($beneficiary));
+    }
+
+    public function testMemberShouldGetSharedRootFoldersOnly()
+    {
+        self::ensureKernelShutdown();
+        $beneficiary = BeneficiaireFactory::findByEmail(BeneficiaryFixture::BENEFICIARY_MAIL)->object();
+        $this->loginUser(MemberFixture::MEMBER_MAIL);
+        $manager = static::getContainer()->get(FolderManager::class);
+        $this->assertNotEquals($beneficiary->getRootFolders(), $manager->getRootFolders($beneficiary));
+        $this->assertEquals($beneficiary->getSharedRootFolders(), $manager->getRootFolders($beneficiary));
+    }
+}


### PR DESCRIPTION
[Ticket](https://trello.com/c/ryBKbp5K/5494-etqp-quand-je-d%C3%A9place-un-dossier-ou-un-document-je-devrais-voir-uniquement-larborescence-des-dossiers-partag%C3%A9s-pour-y-d%C3%A9placer-m)
