### PR TITLE
Limiter les fichiers de deprecations conservés sur le serveur

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -6,7 +6,7 @@ monolog:
             type: rotating_file
             channels: [ deprecation ]
             path: "%kernel.logs_dir%/deprecations/%kernel.environment%.deprecations.log"
-            max_files: 10
+            max_files: 2
 
 when@dev:
     monolog:


### PR DESCRIPTION
[Ticket](https://trello.com/c/EPD3HK9k/5581-limiter-les-fichiers-de-deprecations-conserv%C3%A9s-sur-le-serveur)
