### PR TITLE
:rocket: 2.81.1

### DIFF
--- a/assets/js/home/openstreetmap-marker-generator.js
+++ b/assets/js/home/openstreetmap-marker-generator.js
@@ -24,7 +24,7 @@ $(document).ready(($) => {
     const getPopupTemplate = (centers) => {
         $.each(centers, (key, center) => {
                 const {lat, lng, pays, nom, ville} = center.adresse;
-                if (lat !== null && lng !== null && pays.toLowerCase() === 'france') {
+                if (lat !== null && lng !== null) {
                     let marker = L.marker([lat, lng], {icon: greenIcon}).addTo(map);
                     marker.bindPopup(`<b>
                                             <div>


### PR DESCRIPTION
**Improvement :**
- :recycle: [Home] Reword training with guidance 

**Bug :**
- :bug: [Home/Map] Display centers even if country is not France

> French Release

**Améliorations :**
- :recycle: [Home] Lien aux supports de formation retirés + changement de wording formation -> accompagnement

**Bugs :**
- :bug: [Home/CarteCentres] Les centres qui ne possèdent pas le pays "France" sont quand même affichés sur la carte